### PR TITLE
FIX: Wrong API Endpoint Called for NextJS

### DIFF
--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -49,6 +49,8 @@ services:
       # live outside the backend folder.
       context: ../
       dockerfile: docker/frontend/Dockerfile
+      args:
+        API_BASE_URL: http://adonis.localhost
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.next.entrypoints=web"
@@ -58,3 +60,4 @@ services:
     restart: always
     depends_on:
       - traefik
+      - adonisjs

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -2,6 +2,10 @@
 
 FROM node:18-alpine AS base
 
+ARG API_BASE_URL
+ENV API_BASE_URL=$API_BASE_URL
+ENV HOSTNAME="0.0.0.0"
+
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -60,5 +64,4 @@ EXPOSE 3333
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
-ENV HOSTNAME="0.0.0.0"
 CMD ["node", "server.js"]


### PR DESCRIPTION
### Frontend and Docker Enhancements

#### `docker/compose.dev.yml`
- Added `API_BASE_URL` build argument to the `frontend` service for dynamic API base URL configuration.
- Updated service dependencies to include `adonisjs` to ensure proper startup order and orchestration.

#### `docker/frontend/Dockerfile`
- Introduced `API_BASE_URL` as both an `ARG` and `ENV` to support flexible configuration during build time.
- Moved `HOSTNAME` environment variable definition to the top of the file for improved clarity.
- Removed redundant environment variable declarations at the end of the file.
